### PR TITLE
Robustness when relation name is null

### DIFF
--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/ColumnIdentifier.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/ColumnIdentifier.java
@@ -16,7 +16,9 @@
 package de.metanome.algorithm_integration;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a specific column.
@@ -145,7 +147,17 @@ public class ColumnIdentifier implements Comparable<ColumnIdentifier>, Serializa
 
   @Override
   public int compareTo(ColumnIdentifier other) {
-    int tableIdentifierComparison = tableIdentifier.compareTo(other.tableIdentifier);
+    int tableIdentifierComparison;
+    if (this.tableIdentifier == null) {
+      if (other.tableIdentifier == null)
+        tableIdentifierComparison = 0;
+      else
+        tableIdentifierComparison = 1;
+    } else if (other.tableIdentifier == null)
+      tableIdentifierComparison = -1;
+    else
+      tableIdentifierComparison = this.tableIdentifier.compareTo(other.tableIdentifier);
+
     if (0 != tableIdentifierComparison) {
       return tableIdentifierComparison;
     } else {

--- a/backend/src/main/java/de/metanome/backend/input/database/ResultSetIterator.java
+++ b/backend/src/main/java/de/metanome/backend/input/database/ResultSetIterator.java
@@ -41,6 +41,8 @@ public class ResultSetIterator implements RelationalInput {
     this.numberOfColumns = resultSetMetaData.getColumnCount();
     this.nextCalled = false;
     this.relationName = resultSetMetaData.getTableName(1);
+    if (this.relationName == null || this.relationName.isEmpty())
+      this.relationName = "unknown";
     this.columnNames = retrieveColumnNames(resultSetMetaData);
   }
 
@@ -50,7 +52,7 @@ public class ResultSetIterator implements RelationalInput {
 
     for (int i = 0; i < numberOfColumns; i++) {
       String columnLabel = resultSetMetaData.getColumnLabel(i + 1);
-      columnNames.add(columnLabel == null ? String.format("column%03d", i) : columnLabel);
+      columnNames.add(columnLabel == null ? String.format("column%03d", i + 1) : columnLabel);
     }
 
     return ImmutableList.copyOf(columnNames);

--- a/backend/src/main/java/de/metanome/backend/input/database/ResultSetIterator.java
+++ b/backend/src/main/java/de/metanome/backend/input/database/ResultSetIterator.java
@@ -49,7 +49,8 @@ public class ResultSetIterator implements RelationalInput {
     List<String> columnNames = new LinkedList<>();
 
     for (int i = 0; i < numberOfColumns; i++) {
-      columnNames.add(resultSetMetaData.getColumnLabel(i + 1));
+      String columnLabel = resultSetMetaData.getColumnLabel(i + 1);
+      columnNames.add(columnLabel == null ? String.format("column%03d", i) : columnLabel);
     }
 
     return ImmutableList.copyOf(columnNames);


### PR DESCRIPTION
This PR addresses #363. It provides a default relation name, when `ResultIterator` could not infer one. Also, it allows for missing relation names in `ColumnIdentifier`'s `compareTo(...)` method, which is required by `ColumnCombination`s.