### PR TITLE
Backend support for denial constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ metanomedb.script
 *.paw
 config.js
 build.out
+.DS_Store

--- a/algorithm_integration/pom.xml
+++ b/algorithm_integration/pom.xml
@@ -43,8 +43,8 @@ limitations under the License.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
                     <compilerArgument>-Xlint:all</compilerArgument>

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/Operator.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/Operator.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration;
+
+public enum Operator {
+  EQUAL, UNEQUAL, GREATER, LESS, GREATER_EQUAL, LESS_EQUAL;
+
+  private static final double EPSILON = 0.00001d;
+
+  private Operator inverse;
+  private Operator symmetric;
+  private Operator[] implications;
+  private Operator[] transitives;
+  private String shortString;
+
+  public Operator getInverse() {
+    return inverse;
+  }
+
+  public Operator getSymmetric() {
+    return symmetric;
+  }
+
+  public Operator[] getImplications() {
+    return implications;
+  }
+
+  public String getShortString() {
+    return shortString;
+  }
+
+  public Operator[] getTransitives() {
+    return transitives;
+  }
+
+  public boolean isTransitiveWith(Operator op) {
+    for (Operator i : transitives) {
+      if (i == op)
+        return true;
+    }
+    return false;
+  }
+
+  public <T> boolean eval(Comparable<T> value1, T value2) {
+    if (this == EQUAL) {
+      return value1.equals(value2);
+    } else if (this == UNEQUAL) {
+      return !value1.equals(value2);
+    } else {
+      int c = value1.compareTo(value2);
+      switch (this) {
+        case GREATER_EQUAL:
+          return c >= 0;
+        case LESS:
+          return c < 0;
+        case LESS_EQUAL:
+          return c <= 0;
+        case GREATER:
+          return c > 0;
+        default:
+          break;
+      }
+    }
+
+    return false;
+  }
+
+  public boolean eval(int value1, int value2) {
+    switch (this) {
+      case EQUAL:
+        return value1 == value2;
+      case GREATER:
+        return value1 > value2;
+      case GREATER_EQUAL:
+        return value1 >= value2;
+      case LESS:
+        return value1 < value2;
+      case LESS_EQUAL:
+        return value1 <= value2;
+      case UNEQUAL:
+        return value1 != value2;
+    }
+    return false;
+  }
+
+  public boolean eval(double value1, double value2) {
+    switch (this) {
+      case EQUAL:
+        return Math.abs(value1 - value2) < EPSILON;
+      case UNEQUAL:
+        return Math.abs(value1 - value2) >= EPSILON;
+      case GREATER:
+        return value1 > value2;
+      case GREATER_EQUAL:
+        return value1 >= value2;
+      case LESS:
+        return value1 < value2;
+      case LESS_EQUAL:
+        return value1 <= value2;
+    }
+    return false;
+  }
+
+  /**
+   * a {op} b iff ! (a {op.inverse} b)
+   */
+  static {
+    EQUAL.inverse = UNEQUAL;
+    UNEQUAL.inverse = EQUAL;
+    GREATER.inverse = LESS_EQUAL;
+    LESS.inverse = GREATER_EQUAL;
+    GREATER_EQUAL.inverse = LESS;
+    LESS_EQUAL.inverse = GREATER;
+  }
+
+  /**
+   * a {op} b iff b {op.symmetric} a
+   */
+  static {
+    EQUAL.symmetric = EQUAL;
+    UNEQUAL.symmetric = UNEQUAL;
+    GREATER.symmetric = LESS;
+    LESS.symmetric = GREATER;
+    GREATER_EQUAL.symmetric = LESS_EQUAL;
+    LESS_EQUAL.symmetric = GREATER_EQUAL;
+  }
+
+  /**
+   * if a {op} b, then a {op.implications} b
+   */
+  static {
+    EQUAL.implications = new Operator[] {EQUAL, GREATER_EQUAL, LESS_EQUAL};
+    UNEQUAL.implications = new Operator[] {UNEQUAL};
+    GREATER.implications = new Operator[] {GREATER, GREATER_EQUAL, UNEQUAL};
+    LESS.implications = new Operator[] {LESS, LESS_EQUAL, UNEQUAL};
+    GREATER_EQUAL.implications = new Operator[] {GREATER_EQUAL};
+    LESS_EQUAL.implications = new Operator[] {LESS_EQUAL};
+  }
+
+  /**
+   * if a {op} b and b {op.transitives} c, then a {op} c
+   */
+  static {
+    EQUAL.transitives = new Operator[] {EQUAL};
+    UNEQUAL.transitives = new Operator[] {EQUAL};
+    GREATER.transitives = new Operator[] {GREATER, GREATER_EQUAL, EQUAL};
+    LESS.transitives = new Operator[] {LESS, LESS_EQUAL, EQUAL};
+    GREATER_EQUAL.transitives = new Operator[] {GREATER, GREATER_EQUAL, EQUAL};
+    LESS_EQUAL.transitives = new Operator[] {LESS, LESS_EQUAL, EQUAL};
+  }
+
+  /**
+   * a short string that can be used in text output
+   */
+  static {
+    EQUAL.shortString = "==";
+    UNEQUAL.shortString = "<>";
+    GREATER.shortString = ">";
+    LESS.shortString = "<";
+    GREATER_EQUAL.shortString = ">=";
+    LESS_EQUAL.shortString = "<=";
+  }
+
+}

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/Predicate.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/Predicate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2017 by Metanome Project
+ * Copyright 2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.metanome.algorithm_integration.result_receiver;
+package de.metanome.algorithm_integration;
 
+import java.util.Collection;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-public interface OmniscientResultReceiver extends
-  BasicStatisticsResultReceiver,
-  FunctionalDependencyResultReceiver,
-  InclusionDependencyResultReceiver,
-  UniqueColumnCombinationResultReceiver,
-  ConditionalUniqueColumnCombinationResultReceiver,
-  OrderDependencyResultReceiver,
-  MultivaluedDependencyResultReceiver,
-  DenialConstraintResultReceiver {
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
+public interface Predicate {
+
+  @JsonIgnore
+  Collection<ColumnIdentifier> getColumnIdentifiers();
 
 }

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/PredicateConstant.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/PredicateConstant.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+public class PredicateConstant<T extends Comparable<T>> implements Predicate {
+
+  private ColumnIdentifier column1;
+  private int index1;
+
+  private Operator op;
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY,
+      property = "@class")
+  private T constant;
+
+  @JsonCreator
+  public PredicateConstant(@JsonProperty("column1") ColumnIdentifier column1,
+      @JsonProperty("index1") int index1, @JsonProperty("op") Operator op,
+      @JsonProperty("constant") T constant) {
+    super();
+    this.column1 = column1;
+    this.index1 = index1;
+    this.op = op;
+    this.constant = constant;
+  }
+
+  public ColumnIdentifier getColumn1() {
+    return column1;
+  }
+
+  public int getIndex1() {
+    return index1;
+  }
+
+  public Operator getOp() {
+    return op;
+  }
+
+  public T getConstant() {
+    return constant;
+  }
+
+  @Override
+  public Collection<ColumnIdentifier> getColumnIdentifiers() {
+    return Arrays.asList(column1);
+  }
+
+
+  @Override
+  public String toString() {
+    return "t" + index1 + "." + column1 + op.getShortString() + constant;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((column1 == null) ? 0 : column1.hashCode());
+    result = prime * result + ((constant == null) ? 0 : constant.hashCode());
+    result = prime * result + index1;
+    result = prime * result + ((op == null) ? 0 : op.hashCode());
+    return result;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    PredicateConstant other = (PredicateConstant) obj;
+    if (column1 == null) {
+      if (other.column1 != null)
+        return false;
+    } else if (!column1.equals(other.column1))
+      return false;
+    if (constant == null) {
+      if (other.constant != null)
+        return false;
+    } else if (!constant.equals(other.constant))
+      return false;
+    if (index1 != other.index1)
+      return false;
+    if (op != other.op)
+      return false;
+    return true;
+  }
+}

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/PredicateVariable.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/PredicateVariable.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PredicateVariable implements Predicate {
+  private ColumnIdentifier column1;
+  private int index1;
+
+  private Operator op;
+
+  private ColumnIdentifier column2;
+  private int index2;
+
+
+  @JsonCreator
+  public PredicateVariable(@JsonProperty("column1") ColumnIdentifier column1,
+      @JsonProperty("index1") int index1, @JsonProperty("op") Operator op,
+      @JsonProperty("column2") ColumnIdentifier column2, @JsonProperty("index2") int index2) {
+    super();
+    this.column1 = column1;
+    this.index1 = index1;
+    this.op = op;
+    this.column2 = column2;
+    this.index2 = index2;
+  }
+
+  public ColumnIdentifier getColumn1() {
+    return column1;
+  }
+
+  public int getIndex1() {
+    return index1;
+  }
+
+  public Operator getOp() {
+    return op;
+  }
+
+  public ColumnIdentifier getColumn2() {
+    return column2;
+  }
+
+  public int getIndex2() {
+    return index2;
+  }
+
+  @Override
+  public Collection<ColumnIdentifier> getColumnIdentifiers() {
+    return Arrays.asList(column1, column2);
+  }
+
+  @Override
+  public String toString() {
+    return "t" + index1 + "." + column1 + op.getShortString() + "t" + index2 + "." + column2;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((column1 == null) ? 0 : column1.hashCode());
+    result = prime * result + ((column2 == null) ? 0 : column2.hashCode());
+    result = prime * result + index1;
+    result = prime * result + index2;
+    result = prime * result + ((op == null) ? 0 : op.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    PredicateVariable other = (PredicateVariable) obj;
+    if (column1 == null) {
+      if (other.column1 != null)
+        return false;
+    } else if (!column1.equals(other.column1))
+      return false;
+    if (column2 == null) {
+      if (other.column2 != null)
+        return false;
+    } else if (!column2.equals(other.column2))
+      return false;
+    if (index1 != other.index1)
+      return false;
+    if (index2 != other.index2)
+      return false;
+    if (op != other.op)
+      return false;
+    return true;
+  }
+
+}

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/algorithm_types/DenialConstraintAlgorithm.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/algorithm_types/DenialConstraintAlgorithm.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration.algorithm_types;
+
+import de.metanome.algorithm_integration.Algorithm;
+import de.metanome.algorithm_integration.result_receiver.DenialConstraintResultReceiver;
+
+/**
+ * An {@link Algorithm} that discovers denial constraints.
+ */
+public interface DenialConstraintAlgorithm extends Algorithm {
+
+  /**
+   * Sets a {@link DenialConstraintResultReceiver} to send the results to.
+   *
+   * @param resultReceiver the result receiver the algorithm sents found
+   *        {@link de.metanome.algorithm_integration.results.DenialConstraint}s to.
+   */
+  void setResultReceiver(DenialConstraintResultReceiver resultReceiver);
+
+}

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/result_receiver/DenialConstraintResultReceiver.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/result_receiver/DenialConstraintResultReceiver.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration.result_receiver;
+
+import de.metanome.algorithm_integration.algorithm_types.DenialConstraintAlgorithm;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+
+/**
+ * Receives the results of a {@link DenialConstraintAlgorithm}.
+ */
+public interface DenialConstraintResultReceiver {
+
+  /**
+   * Receives a {@link DenialConstraint} from a {@link DenialConstraintAlgorithm}.
+   *
+   * @param denialConstraint a found {@link DenialConstraint}
+   * @throws de.metanome.algorithm_integration.result_receiver.CouldNotReceiveResultException if no
+   *         result could be received
+   * @throws ColumnNameMismatchException if the column names of the result does not match the column
+   *         names of the input
+   */
+  void receiveResult(DenialConstraint denialConstraint)
+      throws CouldNotReceiveResultException, ColumnNameMismatchException;
+
+  /**
+   * Check if the table/column names of the given result are equal to those in the input.
+   *
+   * @param result the result
+   * @return true, if the names are accepted, false otherwise
+   */
+  Boolean acceptedResult(DenialConstraint result);
+}

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/results/DenialConstraint.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/results/DenialConstraint.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration.results;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import de.metanome.algorithm_integration.Predicate;
+import de.metanome.algorithm_integration.result_receiver.ColumnNameMismatchException;
+import de.metanome.algorithm_integration.result_receiver.CouldNotReceiveResultException;
+import de.metanome.algorithm_integration.result_receiver.OmniscientResultReceiver;
+
+public class DenialConstraint implements Result {
+
+  private static final long serialVersionUID = -3940142594679991666L;
+  public static final String NOT = "\u00AC";
+  public static final String AND = "^";
+
+  private final Set<Predicate> predicates;
+
+  public DenialConstraint() {
+    this.predicates = new HashSet<>();
+  }
+
+  public DenialConstraint(Predicate... predicates) {
+    this.predicates = new HashSet<Predicate>(Arrays.asList(predicates));
+  }
+
+  @Override
+  public void sendResultTo(OmniscientResultReceiver resultReceiver)
+      throws CouldNotReceiveResultException, ColumnNameMismatchException {
+    resultReceiver.receiveResult(this);
+  }
+
+  public Collection<Predicate> getPredicates() {
+    return Collections.unmodifiableCollection(predicates);
+  }
+  
+  @JsonIgnore
+  public int getPredicateCount() {
+    return predicates.size();
+  }
+
+
+  @Override
+  public String toString() {
+    return NOT + "("
+        + predicates.stream().map(p -> p.toString()).sorted().collect(Collectors.joining(AND))
+        + ")";
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((predicates == null) ? 0 : predicates.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DenialConstraint other = (DenialConstraint) obj;
+    if (predicates == null) {
+      if (other.predicates != null)
+        return false;
+    } else if (!predicates.equals(other.predicates))
+      return false;
+    return true;
+  }
+}

--- a/algorithm_integration/src/main/java/de/metanome/algorithm_integration/results/Result.java
+++ b/algorithm_integration/src/main/java/de/metanome/algorithm_integration/results/Result.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ import javax.xml.bind.annotation.XmlTransient;
   @JsonSubTypes.Type(value = InclusionDependency.class, name = "InclusionDependency"),
   @JsonSubTypes.Type(value = OrderDependency.class, name = "OrderDependency"),
   @JsonSubTypes.Type(value = UniqueColumnCombination.class, name = "UniqueColumnCombination"),
-  @JsonSubTypes.Type(value = MultivaluedDependency.class, name = "MultivaluedDependency")
+  @JsonSubTypes.Type(value = MultivaluedDependency.class, name = "MultivaluedDependency"),
+  @JsonSubTypes.Type(value = DenialConstraint.class, name = "DenialConstraint")
 })
 public interface Result extends Serializable {
 

--- a/algorithm_integration/src/test/java/de/metanome/algorithm_integration/results/DenialConstraintTest.java
+++ b/algorithm_integration/src/test/java/de/metanome/algorithm_integration/results/DenialConstraintTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithm_integration.results;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import de.metanome.algorithm_integration.Predicate;
+import de.metanome.algorithm_integration.result_receiver.ColumnNameMismatchException;
+import de.metanome.algorithm_integration.result_receiver.CouldNotReceiveResultException;
+import de.metanome.algorithm_integration.result_receiver.OmniscientResultReceiver;
+
+/**
+ * Test for {@link DenialConstraint}
+ */
+public class DenialConstraintTest {
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @After
+  public void tearDown() throws Exception {}
+
+  /**
+   * Test method for {@link DenialConstraint#sendResultTo(OmniscientResultReceiver)}
+   * <p/>
+   * The {@link DenialConstraint} should be sendable to the {@link OmniscientResultReceiver}.
+   */
+  @Test
+  public void testSendResultTo()
+      throws CouldNotReceiveResultException, ColumnNameMismatchException {
+    // Setup
+    OmniscientResultReceiver resultReceiver = mock(OmniscientResultReceiver.class);
+    DenialConstraint dc = new DenialConstraint();
+
+    // Execute functionality
+    dc.sendResultTo(resultReceiver);
+
+    // Check result
+    verify(resultReceiver).receiveResult(dc);
+  }
+
+  /**
+   * Test method for {@link DenialConstraint#DenialConstraint(Predicate)}
+   * <p/>
+   * A {@link DenialConstraint} should store the predicedst.
+   */
+  @Test
+  public void testConstructor() {
+    // Setup
+    // Expected values
+    Predicate p = mock(Predicate.class);
+    // Execute functionality
+    DenialConstraint dc = new DenialConstraint(p, p);
+
+    // Check result
+    assertTrue(dc.getPredicates().contains(p));
+  }
+
+  /**
+   * Test method for {@link DenialConstraint#toString()}
+   * <p/>
+   * A {@link DenialConstraint} should return a human readable string representation.
+   */
+  @Test
+  public void testToString() {
+    Predicate p1 = mock(Predicate.class);
+    when(p1.toString()).thenReturn("p1");
+    Predicate p2 = mock(Predicate.class);
+    when(p2.toString()).thenReturn("p2");
+
+    // Setup
+    DenialConstraint dc1 = new DenialConstraint(p1, p2);
+    DenialConstraint dc2 = new DenialConstraint(p2, p1);
+    // Expected values
+    String expectedStringRepresentation =
+        DenialConstraint.NOT + "(p1" + DenialConstraint.AND + "p2)";
+
+    // Execute functionality
+    // Check result
+    assertEquals(expectedStringRepresentation, dc1.toString());
+    assertEquals(expectedStringRepresentation, dc2.toString());
+  }
+
+
+  /**
+   * Test method for {@link DenialConstraint#equals(Object)} and {@link DenialConstraint#hashCode()}
+   * <p/>
+   * {@link DenialConstraint}s with equal determinant and dependants should be equal.
+   */
+  @Test
+  public void testEqualsHashCode() {
+    Predicate p1 = mock(Predicate.class);
+    Predicate p2 = mock(Predicate.class);
+    Predicate p3 = mock(Predicate.class);
+
+    // Setup
+    DenialConstraint expectedDC = new DenialConstraint(p1, p2);
+    DenialConstraint expectedEqualDC = new DenialConstraint(p2, p1);
+    DenialConstraint expectedNotEqualDC = new DenialConstraint(p1, p2, p3);
+
+    // Execute functionality
+    // Check result
+    assertEquals(expectedDC, expectedDC);
+    assertEquals(expectedDC.hashCode(), expectedDC.hashCode());
+    assertEquals(expectedDC, expectedEqualDC);
+    assertEquals(expectedDC.hashCode(), expectedEqualDC.hashCode());
+    assertNotEquals(expectedDC, expectedNotEqualDC);
+    assertNotEquals(expectedDC.hashCode(), expectedNotEqualDC.hashCode());
+  }
+
+
+}

--- a/backend/src/main/java/de/metanome/backend/algorithm_execution/AlgorithmExecutor.java
+++ b/backend/src/main/java/de/metanome/backend/algorithm_execution/AlgorithmExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,6 +136,13 @@ public class AlgorithmExecutor implements Closeable {
       basicStatAlgorithm.setResultReceiver(resultReceiver);
 
       results.add(new Result(resultPathPrefix, ResultType.STAT));
+    }
+    
+    if (analyzer.hasType(AlgorithmType.DC)) {
+      DenialConstraintAlgorithm dcAlgorithm = (DenialConstraintAlgorithm) algorithm;
+      dcAlgorithm.setResultReceiver(resultReceiver);
+
+      results.add(new Result(resultPathPrefix, ResultType.DC));
     }
 
     if (analyzer.hasType(AlgorithmType.TEMP_FILE)) {

--- a/backend/src/main/java/de/metanome/backend/algorithm_loading/AlgorithmAnalyzer.java
+++ b/backend/src/main/java/de/metanome/backend/algorithm_loading/AlgorithmAnalyzer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,9 @@ public class AlgorithmAnalyzer {
     }
     if (interfaces.contains(BasicStatisticsAlgorithm.class)) {
       types.add(AlgorithmType.BASIC_STAT);
+    }
+    if (interfaces.contains(DenialConstraintAlgorithm.class)) {
+      types.add(AlgorithmType.DC);
     }
     if (interfaces.contains(TempFileAlgorithm.class)) {
       types.add(AlgorithmType.TEMP_FILE);

--- a/backend/src/main/java/de/metanome/backend/resources/AlgorithmResource.java
+++ b/backend/src/main/java/de/metanome/backend/resources/AlgorithmResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import de.metanome.algorithm_integration.algorithm_types.InclusionDependencyAlgo
 import de.metanome.algorithm_integration.algorithm_types.MultivaluedDependencyAlgorithm;
 import de.metanome.algorithm_integration.algorithm_types.OrderDependencyAlgorithm;
 import de.metanome.algorithm_integration.algorithm_types.UniqueColumnCombinationsAlgorithm;
+import de.metanome.algorithm_integration.results.DenialConstraint;
 import de.metanome.backend.algorithm_loading.AlgorithmAnalyzer;
 import de.metanome.backend.algorithm_loading.AlgorithmFinder;
 import de.metanome.backend.algorithm_loading.AlgorithmJarLoader;
@@ -303,6 +304,21 @@ public class AlgorithmResource implements Resource<Algorithm> {
       throw new WebException(e, Response.Status.BAD_REQUEST);
     }
   }
+  
+  /**
+   * @return all denial constraint algorithms in the database
+   */
+  @GET
+  @Path("/denial-constraint-algorithms/")
+  @Produces("application/json")
+  public List<Algorithm> listDenialConstraintAlgorithms() {
+    try {
+      return listAlgorithms(DenialConstraint.class);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new WebException(e, Response.Status.BAD_REQUEST);
+    }
+  }
 
   /**
    * Lists all algorithms from the database that implement a certain interface, or all if algorithm
@@ -345,6 +361,10 @@ public class AlgorithmResource implements Resource<Algorithm> {
 
     if (interfaces.contains(BasicStatisticsAlgorithm.class)) {
       criteria.add(Restrictions.eq("basicStat", true));
+    }
+    
+    if (interfaces.contains(DenialConstraint.class)) {
+      criteria.add(Restrictions.eq("dc", true));
     }
 
     return (List<Algorithm>) HibernateUtil.queryCriteria(Algorithm.class, criteria.toArray(new Criterion[criteria.size()]));
@@ -411,6 +431,7 @@ public class AlgorithmResource implements Resource<Algorithm> {
     algorithm.setOd(analyzer.hasType(AlgorithmType.OD));
     algorithm.setMvd(analyzer.hasType(AlgorithmType.MVD));
     algorithm.setBasicStat(analyzer.hasType(AlgorithmType.BASIC_STAT));
+    algorithm.setDc(analyzer.hasType(AlgorithmType.DC));
     algorithm.setDatabaseConnection(analyzer.hasType(AlgorithmType.DB_CONNECTION));
     algorithm.setFileInput(analyzer.hasType(AlgorithmType.FILE_INPUT));
     algorithm.setRelationalInput(analyzer.hasType(AlgorithmType.RELATIONAL_INPUT));

--- a/backend/src/main/java/de/metanome/backend/result_postprocessing/ResultPostProcessor.java
+++ b/backend/src/main/java/de/metanome/backend/result_postprocessing/ResultPostProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -318,6 +318,20 @@ public class ResultPostProcessor {
       List<BasicStatisticResult> rankingResults = resultAnalyzer.analyzeResults(basicStatistics);
       // store results
       BasicStatisticResultStore resultsStore = new BasicStatisticResultStore();
+      resultsStore.store(rankingResults);
+      ResultsStoreHolder.register(name, resultsStore);
+      
+    } else if (name.equals(ResultType.DC.getName())) {
+      // read results
+      ResultReader<DenialConstraint> resultReader =
+        new ResultReader<>(ResultType.DC);
+      List<DenialConstraint> denialConstraints = resultReader.readResultsFromFile(fileName);
+      // analyze results
+      ResultAnalyzer<DenialConstraint, DenialConstraintResult>
+        resultAnalyzer = new DenialConstraintResultAnalyzer(inputGenerators, dataIndependent);
+      List<DenialConstraintResult> rankingResults = resultAnalyzer.analyzeResults(denialConstraints);
+      // store results
+      DenialConstraintResultStore resultsStore = new DenialConstraintResultStore();
       resultsStore.store(rankingResults);
       ResultsStoreHolder.register(name, resultsStore);
     }

--- a/backend/src/main/java/de/metanome/backend/result_postprocessing/result_analyzer/DenialConstraintResultAnalyzer.java
+++ b/backend/src/main/java/de/metanome/backend/result_postprocessing/result_analyzer/DenialConstraintResultAnalyzer.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.result_analyzer;
+
+import java.util.ArrayList;
+import java.util.List;
+import de.metanome.algorithm_integration.AlgorithmConfigurationException;
+import de.metanome.algorithm_integration.input.InputGenerationException;
+import de.metanome.algorithm_integration.input.InputIterationException;
+import de.metanome.algorithm_integration.input.RelationalInputGenerator;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+import de.metanome.backend.result_postprocessing.results.DenialConstraintResult;
+
+public class DenialConstraintResultAnalyzer
+    extends ResultAnalyzer<DenialConstraint, DenialConstraintResult> {
+
+
+  public DenialConstraintResultAnalyzer(List<RelationalInputGenerator> inputGenerators,
+      boolean useDataIndependentStatistics)
+      throws InputGenerationException, InputIterationException, AlgorithmConfigurationException {
+    super(inputGenerators, useDataIndependentStatistics);
+  }
+
+  @Override
+  protected List<DenialConstraintResult> analyzeResultsDataIndependent(
+      List<DenialConstraint> prevResults) {
+    List<DenialConstraintResult> results = convertResults(prevResults);
+    return results;
+  }
+
+  @Override
+  protected List<DenialConstraintResult> analyzeResultsDataDependent(
+      List<DenialConstraint> prevResults) {
+    List<DenialConstraintResult> results = convertResults(prevResults);
+    return results;
+  }
+
+  @Override
+  protected List<DenialConstraintResult> convertResults(List<DenialConstraint> prevResults) {
+    List<DenialConstraintResult> results = new ArrayList<>();
+
+    for (DenialConstraint prevResult : prevResults) {
+      DenialConstraintResult result = new DenialConstraintResult(prevResult);
+
+      results.add(result);
+    }
+    return results;
+  }
+}

--- a/backend/src/main/java/de/metanome/backend/result_postprocessing/result_comparator/DenialConstraintResultComparator.java
+++ b/backend/src/main/java/de/metanome/backend/result_postprocessing/result_comparator/DenialConstraintResultComparator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.result_comparator;
+
+import de.metanome.backend.result_postprocessing.results.DenialConstraintResult;
+
+public class DenialConstraintResultComparator extends ResultComparator<DenialConstraintResult> {
+
+  public static final String PREDICATES = "predicates";
+  public static final String SIZE = "size";
+  
+  public DenialConstraintResultComparator(String sortProperty, boolean isAscending) {
+    super(sortProperty, isAscending);
+  }
+
+  @Override
+  protected int compare(DenialConstraintResult o1, DenialConstraintResult o2, String sortProperty) {
+    switch(sortProperty) {
+      case PREDICATES:
+        return o1.getResult().toString().compareTo(o2.getResult().toString());
+      case SIZE:
+        return Integer.compare(o1.getResult().getPredicateCount(), o2.getResult().getPredicateCount());
+    }
+    
+    return 0;
+  }
+
+}

--- a/backend/src/main/java/de/metanome/backend/result_postprocessing/result_ranking/DenialConstraintResultRanking.java
+++ b/backend/src/main/java/de/metanome/backend/result_postprocessing/result_ranking/DenialConstraintResultRanking.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.result_ranking;
+
+import java.util.List;
+import java.util.Map;
+import de.metanome.algorithm_integration.AlgorithmConfigurationException;
+import de.metanome.algorithm_integration.input.InputGenerationException;
+import de.metanome.algorithm_integration.input.InputIterationException;
+import de.metanome.backend.result_postprocessing.helper.TableInformation;
+import de.metanome.backend.result_postprocessing.results.DenialConstraintResult;
+
+public class DenialConstraintResultRanking extends Ranking {
+  protected List<DenialConstraintResult> results;
+
+
+  public DenialConstraintResultRanking(List<DenialConstraintResult> results,
+      Map<String, TableInformation> tableInformationMap) {
+    super(tableInformationMap);
+    this.results = results;
+  }
+
+  @Override
+  public void calculateDataIndependentRankings() {
+
+  }
+
+  @Override
+  public void calculateDataDependentRankings()
+      throws InputGenerationException, InputIterationException, AlgorithmConfigurationException {
+
+  }
+
+}

--- a/backend/src/main/java/de/metanome/backend/result_postprocessing/result_store/DenialConstraintResultStore.java
+++ b/backend/src/main/java/de/metanome/backend/result_postprocessing/result_store/DenialConstraintResultStore.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.result_store;
+
+import de.metanome.backend.result_postprocessing.result_comparator.DenialConstraintResultComparator;
+import de.metanome.backend.result_postprocessing.result_comparator.ResultComparator;
+import de.metanome.backend.result_postprocessing.results.DenialConstraintResult;
+
+public class DenialConstraintResultStore extends ResultsStore<DenialConstraintResult> {
+
+  @Override
+  protected ResultComparator<DenialConstraintResult> getResultComparator(String sortProperty,
+      boolean ascending) {
+    return new DenialConstraintResultComparator(sortProperty, ascending);
+  }
+
+}

--- a/backend/src/main/java/de/metanome/backend/result_postprocessing/results/DenialConstraintResult.java
+++ b/backend/src/main/java/de/metanome/backend/result_postprocessing/results/DenialConstraintResult.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.results;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+
+@JsonTypeName("DenialConstraintResult")
+public class DenialConstraintResult implements RankingResult {
+  // Original result
+  protected DenialConstraint result;
+
+
+  // Needed for serialization
+  public DenialConstraintResult() {}
+
+  public DenialConstraintResult(DenialConstraint result) {
+    this.result = result;
+  }
+
+  public DenialConstraint getResult() {
+    return result;
+  }
+
+  public void setResult(DenialConstraint result) {
+    this.result = result;
+  }
+
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    DenialConstraintResult other = (DenialConstraintResult) obj;
+    return this.result.equals(other.getResult());
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 11).append(this.result).toHashCode();
+  }
+}

--- a/backend/src/main/java/de/metanome/backend/result_receiver/ResultCache.java
+++ b/backend/src/main/java/de/metanome/backend/result_receiver/ResultCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,15 @@ public class ResultCache extends ResultReceiver {
       throw new ColumnNameMismatchException("The column name of the result does not match with the column names in the input!");
     }
   }
+  
+  @Override
+  public void receiveResult(DenialConstraint denialConstraint) throws ColumnNameMismatchException {
+    if (this.acceptedResult(denialConstraint)) {
+      results.add(denialConstraint);
+    } else {
+      throw new ColumnNameMismatchException("The column name of the result does not match with the column names in the input!");
+    }
+  }
 
   /**
    * Should return all results once. Copies the new received results and returns them.
@@ -164,6 +173,8 @@ public class ResultCache extends ResultReceiver {
           printer.receiveResult((OrderDependency) result);
         } else if (result instanceof BasicStatistic) {
           printer.receiveResult((BasicStatistic) result);
+        }  else if (result instanceof DenialConstraint) {
+          printer.receiveResult((DenialConstraint) result);
         }
       } catch (CouldNotReceiveResultException e) {
         e.printStackTrace();
@@ -173,4 +184,5 @@ public class ResultCache extends ResultReceiver {
     }
     printer.close();
   }
+
 }

--- a/backend/src/main/java/de/metanome/backend/result_receiver/ResultCounter.java
+++ b/backend/src/main/java/de/metanome/backend/result_receiver/ResultCounter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package de.metanome.backend.result_receiver;
 import de.metanome.algorithm_integration.result_receiver.CouldNotReceiveResultException;
 import de.metanome.algorithm_integration.results.*;
 import de.metanome.backend.results_db.ResultType;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -83,6 +82,12 @@ public class ResultCounter extends ResultReceiver {
   public void receiveResult(UniqueColumnCombination uniqueColumnCombination)
     throws CouldNotReceiveResultException {
     this.addCount(ResultType.UCC);
+  }
+
+  @Override
+  public void receiveResult(DenialConstraint denialConstraint)
+      throws CouldNotReceiveResultException {
+    this.addCount(ResultType.DC);
   }
 
   protected void addCount(ResultType type) throws CouldNotReceiveResultException {

--- a/backend/src/main/java/de/metanome/backend/result_receiver/ResultPrinter.java
+++ b/backend/src/main/java/de/metanome/backend/result_receiver/ResultPrinter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,6 +265,21 @@ public class ResultPrinter extends ResultReceiver {
         } catch (JsonProcessingException e) {
           throw new CouldNotReceiveResultException("Could not convert the result to JSON!");
         }
+      }
+    } else {
+      throw new ColumnNameMismatchException("The column name of the result does not match with the column names in the input!");
+    }
+  }
+  
+  @Override
+  public void receiveResult(DenialConstraint dc)
+    throws CouldNotReceiveResultException, ColumnNameMismatchException {
+    if (this.acceptedResult(dc)) {
+      try {
+        JsonConverter<DenialConstraint> jsonConverter = new JsonConverter<>();
+        getStream(ResultType.DC).println(jsonConverter.toJsonString(dc));
+      } catch (JsonProcessingException e) {
+        throw new CouldNotReceiveResultException("Could not convert the result to JSON!");
       }
     } else {
       throw new ColumnNameMismatchException("The column name of the result does not match with the column names in the input!");

--- a/backend/src/main/java/de/metanome/backend/result_receiver/ResultReader.java
+++ b/backend/src/main/java/de/metanome/backend/result_receiver/ResultReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,11 @@ public class ResultReader<T extends Result> {
     } else if (name.equals(ResultType.STAT.getName())) {
       JsonConverter<BasicStatistic> jsonConverter = new JsonConverter<>();
       return jsonConverter.fromJsonString(str, BasicStatistic.class);
-
+      
+    } else if (name.equals(ResultType.DC.getName())) {
+      JsonConverter<DenialConstraint> jsonConverter = new JsonConverter<>();
+      return jsonConverter.fromJsonString(str, DenialConstraint.class);
+      
     }
 
     return null;
@@ -141,14 +145,15 @@ public class ResultReader<T extends Result> {
     throws IOException {
     File resultFile = new File(fileName);
 
-    BufferedReader br = new BufferedReader(new FileReader(resultFile));
-    String line;
-    while ((line = br.readLine()) != null) {
-      if (line.startsWith(ResultCounter.HEADER)) {
-        continue;
+    try (BufferedReader br = new BufferedReader(new FileReader(resultFile))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (line.startsWith(ResultCounter.HEADER)) {
+          continue;
+        }
+  
+        return Integer.valueOf(line.split(": ")[1]);
       }
-
-      return Integer.valueOf(line.split(": ")[1]);
     }
     return 0;
   }

--- a/backend/src/main/java/de/metanome/backend/result_receiver/ResultReceiver.java
+++ b/backend/src/main/java/de/metanome/backend/result_receiver/ResultReceiver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package de.metanome.backend.result_receiver;
 
 import de.metanome.algorithm_integration.ColumnIdentifier;
+import de.metanome.algorithm_integration.Predicate;
 import de.metanome.algorithm_integration.results.*;
 
 import java.io.File;
@@ -210,6 +211,26 @@ public abstract class ResultReceiver implements CloseableOmniscientResultReceive
     for (ColumnIdentifier ci : result.getColumnCombination().getColumnIdentifiers()) {
       if (! this.columnAccepted(ci)) {
         return false;
+      }
+    }
+    return true;
+  }
+  
+  /**
+   * Check if the table/column names of the given result are contained in the accepted column names.
+   * @param result the result
+   * @return true, if the names are accepted, false otherwise
+   */
+  @Override
+  public Boolean acceptedResult(DenialConstraint result) {
+    if (this.acceptedColumns == null) {
+      return true;
+    }
+    for (Predicate p : result.getPredicates()) {
+      for(ColumnIdentifier ci : p.getColumnIdentifiers()) {
+        if (! this.columnAccepted(ci)) {
+          return false;
+        }
       }
     }
     return true;

--- a/backend/src/main/java/de/metanome/backend/results_db/Algorithm.java
+++ b/backend/src/main/java/de/metanome/backend/results_db/Algorithm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,8 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
   protected String name;
   protected String author;
   protected String description;
+
+  // OUTPUT
   //Todo: Introduce types Hashset instead of booleans - after finding way around Hibernate problems
   protected boolean ind;
   protected boolean fd;
@@ -55,11 +57,14 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
   protected boolean cucc;
   protected boolean od;
   protected boolean mvd;
+  protected boolean basicStat;
+  protected boolean dc;
+
+  // INPUT
   protected boolean relationalInput;
   protected boolean databaseConnection;
   protected boolean tableInput;
   protected boolean fileInput;
-  protected boolean basicStat;
   protected List<Execution> executions = new ArrayList<>();
 
   /**
@@ -85,7 +90,8 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
    */
   public Algorithm(String fileName, Set<Class<?>> algorithmInterfaces) {
     this(fileName);
-
+    
+    // INPUT
     this.ind = algorithmInterfaces.contains(InclusionDependencyAlgorithm.class);
     this.fd = algorithmInterfaces.contains(FunctionalDependencyAlgorithm.class);
     this.ucc = algorithmInterfaces.contains(UniqueColumnCombinationsAlgorithm.class);
@@ -93,6 +99,8 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
     this.od = algorithmInterfaces.contains(OrderDependencyAlgorithm.class);
     this.mvd = algorithmInterfaces.contains(MultivaluedDependencyAlgorithm.class);
     this.basicStat = algorithmInterfaces.contains(BasicStatisticsAlgorithm.class);
+    this.dc = algorithmInterfaces.contains(DenialConstraintAlgorithm.class);
+    // OUTPUT
     this.fileInput = algorithmInterfaces.contains(FileInputParameterAlgorithm.class);
     this.tableInput = algorithmInterfaces.contains(TableInputParameterAlgorithm.class);
     this.relationalInput = algorithmInterfaces.contains(RelationalInputParameterAlgorithm.class);
@@ -225,6 +233,24 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
 	this.mvd = isMvd;
 	return this;
   }
+  
+  public boolean isBasicStat() {
+    return basicStat;
+  }
+
+  public Algorithm setBasicStat(boolean isBasicStat) {
+    this.basicStat = isBasicStat;
+    return this;
+  }
+  
+  public boolean isDc() {
+    return dc;
+  }
+
+  public Algorithm setDc(boolean isDc) {
+    this.dc = isDc;
+    return this;
+  }
 
   public boolean isRelationalInput() {
     return relationalInput;
@@ -259,15 +285,6 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
 
   public Algorithm setFileInput(boolean isFileInput) {
     this.fileInput = isFileInput;
-    return this;
-  }
-
-  public boolean isBasicStat() {
-    return basicStat;
-  }
-
-  public Algorithm setBasicStat(boolean isBasicStat) {
-    this.basicStat = isBasicStat;
     return this;
   }
 
@@ -336,6 +353,7 @@ public class Algorithm implements Serializable, Comparable<Algorithm> {
       + ", cucc=" + cucc
       + ", od=" + od
       + ", mvd=" + mvd
+      + ", dc=" + dc
       + ", relationalInput=" + relationalInput
       + ", databaseConnection=" + databaseConnection
       + ", tableInput=" + tableInput

--- a/backend/src/main/java/de/metanome/backend/results_db/AlgorithmContentEquals.java
+++ b/backend/src/main/java/de/metanome/backend/results_db/AlgorithmContentEquals.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,9 @@ public class AlgorithmContentEquals {
       return false;
     }
     if (!(algo1.isMvd() == algo2.isMvd())) {
+      return false;
+    }
+    if (!(algo1.isDc() == algo2.isDc())) {
       return false;
     }
     if (!(algo1.isFileInput() == algo2.isFileInput())) {

--- a/backend/src/main/java/de/metanome/backend/results_db/AlgorithmType.java
+++ b/backend/src/main/java/de/metanome/backend/results_db/AlgorithmType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ public enum AlgorithmType implements Serializable {
   OD("Order Dependency Algorithm", ResultType.OD),
   MVD("Multivalued Dependency Algorithm", ResultType.MVD),
   BASIC_STAT("Basic Statistic Algorithm", ResultType.STAT),
+  DC("Denial Constraint Algorithm", ResultType.DC),
   TEMP_FILE("Temporary File Algorithm", null),
   RELATIONAL_INPUT("Relational Input Algorithm", null),
   FILE_INPUT("File Input Algorithm", null),

--- a/backend/src/main/java/de/metanome/backend/results_db/ResultType.java
+++ b/backend/src/main/java/de/metanome/backend/results_db/ResultType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ public enum ResultType implements Serializable {
   CUCC("_cuccs", "Conditional Unique Column Combination"),
   IND("_inds", "Inclusion Dependency"),
   OD("_ods", "Order Dependency"),
-  MVD("_mvds", "Multivalued Dependency");
+  MVD("_mvds", "Multivalued Dependency"),
+  DC("_dcs", "Denial Constraint");
 
   private String ending;
   private String name;

--- a/backend/src/test/java/de/metanome/backend/resources/AlgorithmResourceTest.java
+++ b/backend/src/test/java/de/metanome/backend/resources/AlgorithmResourceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +201,28 @@ public class AlgorithmResourceTest {
 
     // Execute functionality
     List<Algorithm> actualAlgorithms = resource.listBasicStatisticsAlgorithms();
+
+    // Check result
+    assertThat(actualAlgorithms,
+      IsIterableContainingInAnyOrder.containsInAnyOrder(expectedAlgorithm));
+
+    // Cleanup
+    HibernateUtil.clear();
+  }
+  
+  @Test
+  public void testListDenialConstraintAlgorithms() throws Exception {
+    // Setup
+    HibernateUtil.clear();
+
+    // Expected values
+    Algorithm expectedAlgorithm = new Algorithm("example_dc_algorithm.jar")
+      .setName("dc")
+      .setDc(true);
+    HibernateUtil.store(expectedAlgorithm);
+
+    // Execute functionality
+    List<Algorithm> actualAlgorithms = resource.listDenialConstraintAlgorithms();
 
     // Check result
     assertThat(actualAlgorithms,

--- a/backend/src/test/java/de/metanome/backend/result_postprocessing/result_comparator/DenialConstraintResultComparatorTest.java
+++ b/backend/src/test/java/de/metanome/backend/result_postprocessing/result_comparator/DenialConstraintResultComparatorTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.result_comparator;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import de.metanome.algorithm_integration.Predicate;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+import de.metanome.backend.result_postprocessing.results.DenialConstraintResult;
+
+public class DenialConstraintResultComparatorTest {
+  DenialConstraintResult dc1;
+  DenialConstraintResult dc2;
+
+  @Before
+  public void setUp() {
+    Predicate p1 = mock(Predicate.class);
+    when(p1.toString()).thenReturn("p1");
+    Predicate p2 = mock(Predicate.class);
+    when(p1.toString()).thenReturn("p2");
+    DenialConstraint result1 = new DenialConstraint(p1, p2);
+    dc1 = new DenialConstraintResult(result1);
+
+    DenialConstraint result2 = new DenialConstraint(p2);
+    dc2 = new DenialConstraintResult(result2);
+  }
+
+  @Test
+  public void compare1() {
+    DenialConstraintResultComparator resultComparator = new DenialConstraintResultComparator(
+        DenialConstraintResultComparator.PREDICATES, true);
+    assertTrue(resultComparator.compare(dc1, dc2) > 0);
+  }
+
+  @Test
+  public void compare2() {
+    DenialConstraintResultComparator resultComparator = new DenialConstraintResultComparator(
+        DenialConstraintResultComparator.PREDICATES, false);
+    assertTrue(resultComparator.compare(dc1, dc2) < 0);
+  }
+
+  @Test
+  public void compare3() {
+    DenialConstraintResultComparator resultComparator = new DenialConstraintResultComparator(
+        DenialConstraintResultComparator.SIZE, true);
+    assertTrue(resultComparator.compare(dc1, dc2) > 0);
+  }
+
+  @Test
+  public void compare4() {
+    DenialConstraintResultComparator resultComparator = new DenialConstraintResultComparator(
+        DenialConstraintResultComparator.SIZE, false);
+    assertTrue(resultComparator.compare(dc1, dc2) < 0);
+  }
+
+
+}

--- a/backend/src/test/java/de/metanome/backend/result_postprocessing/result_ranking/DenialConstraintRankingTest.java
+++ b/backend/src/test/java/de/metanome/backend/result_postprocessing/result_ranking/DenialConstraintRankingTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.result_ranking;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import de.metanome.algorithm_integration.Predicate;
+import de.metanome.algorithm_integration.input.InputGenerationException;
+import de.metanome.algorithm_integration.input.InputIterationException;
+import de.metanome.algorithm_integration.input.RelationalInput;
+import de.metanome.algorithm_integration.input.RelationalInputGenerator;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+import de.metanome.backend.result_postprocessing.file_fixture.FileFixtureGeneral;
+import de.metanome.backend.result_postprocessing.results.DenialConstraintResult;
+
+public class DenialConstraintRankingTest {
+  List<DenialConstraintResult> denialConstraintResults;
+
+  @Before
+  public void setUp() throws Exception {
+    final FileFixtureGeneral fileFixture = new FileFixtureGeneral();
+    RelationalInputGenerator relationalInputGenerator = new RelationalInputGenerator() {
+      @Override
+      public RelationalInput generateNewCopy() throws InputGenerationException {
+        try {
+          return fileFixture.getTestData();
+        } catch (InputIterationException e) {
+          return null;
+        }
+      }
+      @Override
+      public void close() throws Exception {}
+    };
+    
+    DenialConstraint dc1 = new DenialConstraint(mock(Predicate.class));
+    DenialConstraint dc2 = new DenialConstraint(mock(Predicate.class));
+
+    DenialConstraintResult result1 = new DenialConstraintResult(dc1);
+    DenialConstraintResult result2 = new DenialConstraintResult(dc2);
+
+    denialConstraintResults = new ArrayList<>();
+    denialConstraintResults.add(result1);
+    denialConstraintResults.add(result2);
+  }
+
+  @Test
+  public void testInitialization() throws Exception {
+    // Execute functionality
+    DenialConstraintResultRanking ranking = new DenialConstraintResultRanking(denialConstraintResults, null);
+
+    // Check
+    assertNotNull(ranking.results);
+  }
+}

--- a/backend/src/test/java/de/metanome/backend/result_postprocessing/results/DenialConstraintResultTest.java
+++ b/backend/src/test/java/de/metanome/backend/result_postprocessing/results/DenialConstraintResultTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.backend.result_postprocessing.results;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import de.metanome.algorithm_integration.input.InputGenerationException;
+import de.metanome.algorithm_integration.input.InputIterationException;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+
+public class DenialConstraintResultTest {
+  @Test
+  public void testInitialization() throws InputGenerationException, InputIterationException {
+    // Expected Values
+    DenialConstraint expectedResult = new DenialConstraint();
+
+    // Execute functionality
+    DenialConstraintResult rankingResult = new DenialConstraintResult(expectedResult);
+
+    // Check
+    assertEquals(expectedResult, rankingResult.getResult());
+  }
+
+  @Test
+  public void testEquals() throws InputGenerationException, InputIterationException {
+    // Set up
+    DenialConstraint expectedResult = new DenialConstraint();
+    DenialConstraint expectedResult2 = new DenialConstraint();
+
+    // Execute functionality
+    DenialConstraintResult rankingResult1 = new DenialConstraintResult(expectedResult);
+    DenialConstraintResult rankingResult2 = new DenialConstraintResult(expectedResult2);
+
+    // Check
+    assertEquals(rankingResult1, rankingResult1);
+    assertEquals(rankingResult1, rankingResult2);
+  }
+}

--- a/backend/src/test/java/de/metanome/backend/result_receiver/ResultCounterTest.java
+++ b/backend/src/test/java/de/metanome/backend/result_receiver/ResultCounterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 by Metanome Project
+ * Copyright 2015-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import de.metanome.algorithm_integration.result_receiver.CouldNotReceiveResultException;
 import de.metanome.algorithm_integration.results.BasicStatistic;
+import de.metanome.algorithm_integration.results.DenialConstraint;
 import de.metanome.algorithm_integration.results.InclusionDependency;
 import de.metanome.algorithm_integration.results.UniqueColumnCombination;
 import de.metanome.backend.results_db.ResultType;
@@ -47,6 +48,7 @@ public class ResultCounterTest {
     // Expected
     BasicStatistic basicStatistic = mock(BasicStatistic.class);
     InclusionDependency inclusionDependency = mock(InclusionDependency.class);
+    DenialConstraint dc = mock(DenialConstraint.class);
 
     // Execute functionality
     resultCounter.receiveResult(basicStatistic);
@@ -54,14 +56,17 @@ public class ResultCounterTest {
     // Check result
     assertTrue(resultCounter.getResults().get(ResultType.STAT) == 1);
     assertNull(resultCounter.getResults().get(ResultType.IND));
+    assertNull(resultCounter.getResults().get(ResultType.DC));
 
     // Execute functionality
     resultCounter.receiveResult(basicStatistic);
     resultCounter.receiveResult(inclusionDependency);
+    resultCounter.receiveResult(dc);
 
     // Check result
     assertTrue(resultCounter.getResults().get(ResultType.STAT) == 2);
     assertTrue(resultCounter.getResults().get(ResultType.IND) == 1);
+    assertTrue(resultCounter.getResults().get(ResultType.DC) == 1);
   }
 
   /**

--- a/backend/src/test/java/de/metanome/backend/results_db/AlgorithmContentEqualsTest.java
+++ b/backend/src/test/java/de/metanome/backend/results_db/AlgorithmContentEqualsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014, 2016 by Metanome Project
+ * Copyright 2014, 2016-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,9 @@ public class AlgorithmContentEqualsTest {
 
     Algorithm notEqualAlgorithmIsNotBasicStat = buildEqualAlgorithm();
     notEqualAlgorithmIsNotBasicStat.setBasicStat(false);
+    
+    Algorithm notEqualAlgorithmIsNotDc = buildEqualAlgorithm();
+    notEqualAlgorithmIsNotDc.setDc(false);
 
     // Execute functionality
     // Check result
@@ -84,6 +87,7 @@ public class AlgorithmContentEqualsTest {
     assertFalse(AlgorithmContentEquals.contentEquals(algorithm, notEqualAlgorithmIsNotFd));
     assertFalse(AlgorithmContentEquals.contentEquals(algorithm, notEqualAlgorithmIsNotUcc));
     assertFalse(AlgorithmContentEquals.contentEquals(algorithm, notEqualAlgorithmIsNotBasicStat));
+    assertFalse(AlgorithmContentEquals.contentEquals(algorithm, notEqualAlgorithmIsNotDc));
   }
 
   /**
@@ -112,6 +116,7 @@ public class AlgorithmContentEqualsTest {
     boolean expectedIsFd = true;
     boolean expectedIsUcc = true;
     boolean expectedIsBasicStat = true;
+    boolean expectedIsDc = true;
 
     Algorithm algorithm = new Algorithm(expectedFileName);
     algorithm.setName(expectedName);
@@ -121,6 +126,7 @@ public class AlgorithmContentEqualsTest {
     algorithm.setFd(expectedIsFd);
     algorithm.setUcc(expectedIsUcc);
     algorithm.setBasicStat(expectedIsBasicStat);
+    algorithm.setDc(expectedIsDc);
 
     return algorithm;
   }

--- a/backend/src/test/java/de/metanome/backend/results_db/AlgorithmTest.java
+++ b/backend/src/test/java/de/metanome/backend/results_db/AlgorithmTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2016 by Metanome Project
+ * Copyright 2014-2017 by Metanome Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,9 @@ public class AlgorithmTest {
     algorithmInterfaces.add(OrderDependencyAlgorithm.class);
     algorithmInterfaces.add(InclusionDependencyAlgorithm.class);
     algorithmInterfaces.add(FunctionalDependencyAlgorithm.class);
+    algorithmInterfaces.add(MultivaluedDependencyAlgorithm.class);
     algorithmInterfaces.add(BasicStatisticsAlgorithm.class);
+    algorithmInterfaces.add(DenialConstraintAlgorithm.class);
     algorithmInterfaces.add(RelationalInputParameterAlgorithm.class);
     algorithmInterfaces.add(FileInputParameterAlgorithm.class);
     algorithmInterfaces.add(TableInputParameterAlgorithm.class);
@@ -66,7 +68,9 @@ public class AlgorithmTest {
     assertTrue(actualAlgorithm.isUcc());
     assertTrue(actualAlgorithm.isCucc());
     assertTrue(actualAlgorithm.isOd());
+    assertTrue(actualAlgorithm.isMvd());
     assertTrue(actualAlgorithm.isBasicStat());
+    assertTrue(actualAlgorithm.isDc());
     assertTrue(actualAlgorithm.isDatabaseConnection());
     assertTrue(actualAlgorithm.isFileInput());
     assertTrue(actualAlgorithm.isRelationalInput());
@@ -104,7 +108,9 @@ public class AlgorithmTest {
     assertTrue(actualAlgorithm.isUcc());
     assertFalse(actualAlgorithm.isCucc());
     assertFalse(actualAlgorithm.isOd());
+    assertFalse(actualAlgorithm.isMvd());
     assertFalse(actualAlgorithm.isBasicStat());
+    assertFalse(actualAlgorithm.isDc());
     assertEquals(expectedName, actualAlgorithm.getName());
     assertEquals(expectedAuthor, actualAlgorithm.getAuthor());
     assertEquals(expectedDescription, actualAlgorithm.getDescription());

--- a/testing_algorithms/example_dc_algorithm/.gitignore
+++ b/testing_algorithms/example_dc_algorithm/.gitignore
@@ -1,0 +1,3 @@
+/target
+.classpath
+/.settings

--- a/testing_algorithms/example_dc_algorithm/pom.xml
+++ b/testing_algorithms/example_dc_algorithm/pom.xml
@@ -1,0 +1,95 @@
+<!--
+Copyright 2016-2017 by the Metanome Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>example_dc_algorithm</artifactId>
+    <packaging>jar</packaging>
+
+    <name>example_dc_algorithm</name>
+
+    <parent>
+        <groupId>de.metanome</groupId>
+        <artifactId>metanome</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                    <compilerArgument>-Xlint:all</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Algorithm-Bootstrap-Class>
+                                de.metanome.algorithms.testing.example_dc_algorithm.ExampleAlgorithm
+                            </Algorithm-Bootstrap-Class>
+                        </manifestEntries>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.metanome</groupId>
+            <artifactId>algorithm_integration</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/testing_algorithms/example_dc_algorithm/src/main/java/de/metanome/algorithms/testing/example_dc_algorithm/ExampleAlgorithm.java
+++ b/testing_algorithms/example_dc_algorithm/src/main/java/de/metanome/algorithms/testing/example_dc_algorithm/ExampleAlgorithm.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithms.testing.example_dc_algorithm;
+
+import java.util.ArrayList;
+import de.metanome.algorithm_integration.AlgorithmConfigurationException;
+import de.metanome.algorithm_integration.AlgorithmExecutionException;
+import de.metanome.algorithm_integration.ColumnIdentifier;
+import de.metanome.algorithm_integration.Operator;
+import de.metanome.algorithm_integration.Predicate;
+import de.metanome.algorithm_integration.PredicateConstant;
+import de.metanome.algorithm_integration.PredicateVariable;
+import de.metanome.algorithm_integration.algorithm_types.DatabaseConnectionParameterAlgorithm;
+import de.metanome.algorithm_integration.algorithm_types.DenialConstraintAlgorithm;
+import de.metanome.algorithm_integration.algorithm_types.FileInputParameterAlgorithm;
+import de.metanome.algorithm_integration.algorithm_types.StringParameterAlgorithm;
+import de.metanome.algorithm_integration.configuration.ConfigurationRequirement;
+import de.metanome.algorithm_integration.configuration.ConfigurationRequirementDatabaseConnection;
+import de.metanome.algorithm_integration.configuration.ConfigurationRequirementFileInput;
+import de.metanome.algorithm_integration.configuration.ConfigurationRequirementString;
+import de.metanome.algorithm_integration.input.DatabaseConnectionGenerator;
+import de.metanome.algorithm_integration.input.FileInputGenerator;
+import de.metanome.algorithm_integration.result_receiver.ColumnNameMismatchException;
+import de.metanome.algorithm_integration.result_receiver.CouldNotReceiveResultException;
+import de.metanome.algorithm_integration.result_receiver.DenialConstraintResultReceiver;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+
+public class ExampleAlgorithm implements DenialConstraintAlgorithm, StringParameterAlgorithm,
+    FileInputParameterAlgorithm, DatabaseConnectionParameterAlgorithm {
+
+  public final static String STRING_IDENTIFIER = "pathToOutputFile";
+  public final static String CSVFILE_IDENTIFIER = "input file";
+  public final static String DATABASE_IDENTIFIER = "DB-connection";
+  protected String path = null;
+  protected String selectedColumn = null;
+  protected DatabaseConnectionGenerator inputGenerator;
+  protected DenialConstraintResultReceiver resultReceiver;
+
+  @Override
+  public ArrayList<ConfigurationRequirement<?>> getConfigurationRequirements() {
+    ArrayList<ConfigurationRequirement<?>> configurationRequirement = new ArrayList<>();
+
+    ConfigurationRequirementString requirementString =
+        new ConfigurationRequirementString(STRING_IDENTIFIER);
+    ConfigurationRequirementFileInput requirementFileInput =
+        new ConfigurationRequirementFileInput(CSVFILE_IDENTIFIER);
+    ConfigurationRequirementDatabaseConnection requirementDatabaseConnection =
+        new ConfigurationRequirementDatabaseConnection(DATABASE_IDENTIFIER);
+
+    requirementString.setRequired(false);
+    requirementFileInput.setRequired(false);
+    requirementDatabaseConnection.setRequired(false);
+
+    configurationRequirement.add(requirementString);
+    configurationRequirement.add(requirementFileInput);
+    configurationRequirement.add(requirementDatabaseConnection);
+
+    return configurationRequirement;
+  }
+
+  @Override
+  public void execute() throws AlgorithmExecutionException {
+    try {
+      ColumnIdentifier c1 = new ColumnIdentifier("WDC_planets.csv", "Name");
+      ColumnIdentifier c2 = new ColumnIdentifier("WDC_planets.csv", "Mass");
+
+      Predicate p1 = new PredicateVariable(c1, 1, Operator.EQUAL, c2, 2);
+      Predicate p2 = new PredicateConstant<Double>(c2, 1, Operator.GREATER, 5.0d);
+      Predicate p3 = new PredicateVariable(c1, 1, Operator.GREATER_EQUAL, c2, 2);
+
+      resultReceiver.receiveResult(new DenialConstraint(p1, p2));
+      resultReceiver.receiveResult(new DenialConstraint(p3));
+    } catch (CouldNotReceiveResultException | ColumnNameMismatchException e) {
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+  @Override
+  public void setResultReceiver(DenialConstraintResultReceiver resultReceiver) {
+    this.resultReceiver = resultReceiver;
+  }
+
+  @Override
+  public void setStringConfigurationValue(String identifier, String... values)
+      throws AlgorithmConfigurationException {
+    if (!identifier.equals(STRING_IDENTIFIER)) {
+      throw new AlgorithmConfigurationException("Incorrect identifier or value list length.");
+    }
+  }
+
+  @Override
+  public void setFileInputConfigurationValue(String identifier, FileInputGenerator... values)
+      throws AlgorithmConfigurationException {
+    if (!identifier.equals(CSVFILE_IDENTIFIER)) {
+      throw new AlgorithmConfigurationException("Incorrect identifier or value list length.");
+    }
+  }
+
+  @Override
+  public void setDatabaseConnectionGeneratorConfigurationValue(String identifier,
+      DatabaseConnectionGenerator... values) throws AlgorithmConfigurationException {
+
+    if (!identifier.equals(DATABASE_IDENTIFIER)) {
+      throw new AlgorithmConfigurationException("Incorrect identifier or value list length.");
+    }
+  }
+
+  @Override
+  public String getAuthors() {
+    return "Metanome Team";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Example algorithm for denial constraints.";
+  }
+
+}

--- a/testing_algorithms/example_dc_algorithm/src/test/java/de/metanome/algorithms/testing/example_dc_algorithm/ExampleAlgorithmTest.java
+++ b/testing_algorithms/example_dc_algorithm/src/test/java/de/metanome/algorithms/testing/example_dc_algorithm/ExampleAlgorithmTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017 by Metanome Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.metanome.algorithms.testing.example_dc_algorithm;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import de.metanome.algorithm_integration.AlgorithmExecutionException;
+import de.metanome.algorithm_integration.configuration.ConfigurationRequirement;
+import de.metanome.algorithm_integration.configuration.ConfigurationRequirementString;
+import de.metanome.algorithm_integration.result_receiver.DenialConstraintResultReceiver;
+import de.metanome.algorithm_integration.results.DenialConstraint;
+
+/**
+ * Test for {@link de.metanome.algorithms.testing.example_dc_algorithm.ExampleAlgorithm}
+ */
+public class ExampleAlgorithmTest {
+
+  protected ExampleAlgorithm algorithm;
+  protected String pathIdentifier;
+  protected String columnIdentifier;
+  protected String anotherColumnIdentifier;
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp() throws Exception {
+    algorithm = new ExampleAlgorithm();
+    pathIdentifier = ExampleAlgorithm.STRING_IDENTIFIER;
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @After
+  public void tearDown() throws Exception {
+
+  }
+
+  /**
+   * Test method for {@link ExampleAlgorithm#getConfigurationRequirements()} <p/> The algorithm
+   * should return one configuration specification of string type
+   */
+  @Test
+  public void testGetConfigurationRequirements() {
+    // Execute functionality
+    List<ConfigurationRequirement<?>>
+        actualConfigurationRequirements =
+        this.algorithm.getConfigurationRequirements();
+
+    // Check result
+    assertEquals(3, actualConfigurationRequirements.size());
+    assertThat(actualConfigurationRequirements.get(0),
+               instanceOf(ConfigurationRequirementString.class));
+  }
+
+  /**
+   * Test method for {@link ExampleAlgorithm#execute()} <p/> When the algorithm is started after
+   * configuration a result should be received.
+   */
+  @Test
+  public void testExecute() throws AlgorithmExecutionException {
+    // Setup
+    DenialConstraintResultReceiver
+        resultReceiver =
+        mock(DenialConstraintResultReceiver.class);
+    this.algorithm.setStringConfigurationValue(pathIdentifier, "something");
+
+    // Execute functionality
+    this.algorithm.setResultReceiver(resultReceiver);
+    this.algorithm.execute();
+
+    // Check result
+    verify(resultReceiver,  times(2)).receiveResult(isA(DenialConstraint.class));
+  }
+}

--- a/testing_algorithms/pom.xml
+++ b/testing_algorithms/pom.xml
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016 by the Metanome Project
+Copyright 2016-2017 by the Metanome Project
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ limitations under the License.
         <module>example_relational_input_algorithm</module>
         <module>example_sql_profiling_algorithm</module>
         <module>example_mvd_algorithm</module>
+        <module>example_dc_algorithm</module>
     </modules>
 
     <build>


### PR DESCRIPTION
This follows the steps from [the wiki](https://github.com/HPI-Information-Systems/Metanome/wiki/Adding-a-new-Algorithm-Type) to add support for denial constraints.

I will file a second pull request to the [Metanome-Frontend](https://github.com/HPI-Information-Systems/Metanome-Frontend) repository, which will include all necessary changes to display DCs in the frontend.