### PR TITLE
Fix definition of TableInputGeneratorMixin

### DIFF
--- a/backend/src/main/java/de/metanome/backend/helper/TableInputGeneratorMixIn.java
+++ b/backend/src/main/java/de/metanome/backend/helper/TableInputGeneratorMixIn.java
@@ -17,14 +17,14 @@ package de.metanome.backend.helper;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import de.metanome.backend.input.file.DefaultFileInputGenerator;
+import de.metanome.backend.input.database.DefaultTableInputGenerator;
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
   property = "type")
 @JsonSubTypes({
-  @JsonSubTypes.Type(value = DefaultFileInputGenerator.class, name = "defaultTableInputGenerator")})
+  @JsonSubTypes.Type(value = DefaultTableInputGenerator.class, name = "defaultTableInputGenerator")})
 public abstract class TableInputGeneratorMixIn {
 
 }


### PR DESCRIPTION
The definition of `TableInputGeneratorMixin` should probably not contain references to the `DefaultFileInputGenerator`. The former version created the following exception and did not make any `TableInputGenerator` available to my algorithm.

```
com.fasterxml.jackson.databind.JsonMappingException: Could not resolve type id 'DefaultTableInputGenerator' into a subtype of [simple type, class de.metanome.algorithm_integration.input.TableInputGenerator]
 at [Source: java.io.StringReader@5e8f9e2d; line: 1, column: 82] (through reference chain: de.metanome.backend.configuration.ConfigurationValueTableInputGenerator["values"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
	at com.fasterxml.jackson.databind.DeserializationContext.unknownTypeException(DeserializationContext.java:793)
	at com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase._findDeserializer(TypeDeserializerBase.java:167)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer._deserializeTypedForId(AsPropertyTypeDeserializer.java:104)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer.deserializeTypedFromObject(AsPropertyTypeDeserializer.java:87)
	at com.fasterxml.jackson.databind.deser.AbstractDeserializer.deserializeWithType(AbstractDeserializer.java:132)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:151)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:18)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:525)
	at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:106)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:242)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:155)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:126)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer._deserializeTypedForId(AsPropertyTypeDeserializer.java:118)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer.deserializeTypedFromObject(AsPropertyTypeDeserializer.java:87)
	at com.fasterxml.jackson.databind.deser.AbstractDeserializer.deserializeWithType(AbstractDeserializer.java:132)
	at com.fasterxml.jackson.databind.deser.impl.TypeWrappedDeserializer.deserialize(TypeWrappedDeserializer.java:41)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:2993)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2098)
	at de.metanome.algorithm_integration.results.JsonConverter.fromJsonString(JsonConverter.java:70)
	at de.metanome.backend.algorithm_execution.AlgorithmExecution.parseConfigurationValues(AlgorithmExecution.java:158)
	at de.metanome.backend.algorithm_execution.AlgorithmExecution.main(AlgorithmExecution.java:210)
```