### PR TITLE
Fix #383 DatabaseConnectionResource return type

### DIFF
--- a/backend/src/main/java/de/metanome/backend/resources/DatabaseConnectionResource.java
+++ b/backend/src/main/java/de/metanome/backend/resources/DatabaseConnectionResource.java
@@ -83,9 +83,9 @@ public class DatabaseConnectionResource implements Resource<DatabaseConnection> 
   @Path("/store")
   @Consumes("application/json")
   @Produces("application/json")
-  public void executeDatabaseStore(DatabaseConnection dbConnection) {
+  public DatabaseConnection executeDatabaseStore(DatabaseConnection dbConnection) {
     try {
-      store(dbConnection);
+      return store(dbConnection);
     } catch (Exception e) {
       e.printStackTrace();
       throw new WebException(e, Response.Status.BAD_REQUEST);


### PR DESCRIPTION
Implements [apidocs](https://metanome.docs.apiary.io/#reference/database-connections/store-a-new-database-connection/store-a-new-database-connection) described behaviour