### PR TITLE
Fix parent pom in testing_algorithms subprojects

### DIFF
--- a/testing_algorithms/example_basic_stat_algorithm/pom.xml
+++ b/testing_algorithms/example_basic_stat_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_cucc_algorithm/pom.xml
+++ b/testing_algorithms/example_cucc_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_dc_algorithm/pom.xml
+++ b/testing_algorithms/example_dc_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_fd_algorithm/pom.xml
+++ b/testing_algorithms/example_fd_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_holistic_algorithm/pom.xml
+++ b/testing_algorithms/example_holistic_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_ind_algorithm/pom.xml
+++ b/testing_algorithms/example_ind_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_indirect_interfaces_algorithm/pom.xml
+++ b/testing_algorithms/example_indirect_interfaces_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_mvd_algorithm/pom.xml
+++ b/testing_algorithms/example_mvd_algorithm/pom.xml
@@ -24,7 +24,7 @@
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_od_algorithm/pom.xml
+++ b/testing_algorithms/example_od_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_relational_input_algorithm/pom.xml
+++ b/testing_algorithms/example_relational_input_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_sql_profiling_algorithm/pom.xml
+++ b/testing_algorithms/example_sql_profiling_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_ucc_algorithm/pom.xml
+++ b/testing_algorithms/example_ucc_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/testing_algorithms/example_wrong_bootstrap_algorithm/pom.xml
+++ b/testing_algorithms/example_wrong_bootstrap_algorithm/pom.xml
@@ -23,7 +23,7 @@ limitations under the License.
 
     <parent>
         <groupId>de.metanome</groupId>
-        <artifactId>metanome</artifactId>
+        <artifactId>testing_algorithms</artifactId>
         <version>1.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
The subprojects of `testing_algorithms` currently have their arifact ID set to `metanome` instead of `testing_algorithms` which sometimes causes the build to fail.
This simply sets the correct artifact ID.