### PR TITLE
corrected messy error message due to unhandled exception bug

### DIFF
--- a/backend/src/main/java/de/metanome/backend/resources/AlgorithmExecutionResource.java
+++ b/backend/src/main/java/de/metanome/backend/resources/AlgorithmExecutionResource.java
@@ -177,6 +177,8 @@ public class AlgorithmExecutionResource {
                   .setInputs(AlgorithmExecution.parseInputs(executionSetting.getInputsJson()));
 
         HibernateUtil.update(execution);
+      } catch (IndexOutOfBoundsException e1) {
+        throw new WebException(exceptionMessage, Response.Status.BAD_REQUEST);
       } catch (EntityStorageException e1) {
         e1.printStackTrace();
         throw new WebException("Could not store execution.", Response.Status.BAD_REQUEST);


### PR DESCRIPTION
turns out when querying aborted executions that are still running, none can be returned and therefore created an unhandled exception in the executeAlgorithm method, thus not leading to throwing a webexception with the correct error message