### PR TITLE
Fixed issue with maven build

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -242,6 +242,7 @@ limitations under the License.
         <dependency>
             <groupId>com.sap.cloud.db.jdbc</groupId>
             <artifactId>ngdbc</artifactId>
+            <version>2.4.62</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
In `backend\pom.xml`, the version was missing for
`com.sap.cloud.db.jdbc:ngdbc:jar`.

This issue was introduced in HPI-Information-Systems/Metanome#411.

Fixes HPI-Information-Systems/Metanome#413.