### PR TITLE
Update dependency to be compatible with ARM-based macOS-Systems

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -123,7 +123,7 @@ limitations under the License.
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.3</version>
+                <version>1.11.0</version>
                 <configuration>
                     <workingDirectory>src</workingDirectory>
                     <installDirectory>target</installDirectory>


### PR DESCRIPTION
This change allows the maven build to succeed on macos-arm64 systems. See [their changelog](https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md) for infos regarding the update, there doesn't seem to be any breaking changes listed.

BTW: when trying to build the source code I found that the current jdk (v17) fails to build Metanome. It only succeeded when downgrading to jdk 11, maybe this would be worth mentioning in the README